### PR TITLE
Removed 4 unnecessary stubbings in RoundhouseActionTest.java

### DIFF
--- a/src/test/java/hudson/plugins/chucknorris/SecondRoundhouseActionTest.java
+++ b/src/test/java/hudson/plugins/chucknorris/SecondRoundhouseActionTest.java
@@ -12,7 +12,7 @@ import junit.framework.TestCase;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-public class RoundhouseActionTest extends TestCase {
+public class SecondRoundhouseActionTest extends TestCase {
 
     private RoundhouseAction action;
 
@@ -25,26 +25,22 @@ public class RoundhouseActionTest extends TestCase {
         action = new RoundhouseAction(Style.BAD_ASS, "Chuck Norris can divide by zero.");
 
         run = mock(Run.class);
-
         lastBuildAction = new RoundhouseAction(Style.ALERT, "Chuck Norris went out of an infinite loop.");
         final Job job = mock(Job.class);
         Run<?, ?> lastRun = mock(Run.class);
-
-        given(run.getParent()).willAnswer(new Answer<Job>() {
-            @Override
-            public Job answer(InvocationOnMock invocation) throws Throwable {
-                return job;
-            }
-        });
-        given(job.getLastCompletedBuild()).willReturn(lastRun);
-        given(lastRun.getActions(eq(RoundhouseAction.class))).willReturn(Arrays.asList(lastBuildAction));
     }
 
-    public void testGetProjectActionsFromLastProjectBuild() {
-        action.onAttached(run);
+    public void testAccessors() {
+        assertEquals(Style.BAD_ASS, action.getStyle());
+        assertEquals("Chuck Norris can divide by zero.", action.getFact());
+        assertEquals("Chuck Norris", action.getDisplayName());
+        assertNull(action.getIconFileName());
+        assertEquals("chucknorris", action.getUrlName());
+    }
 
+    public void testGetProjectActions() {
         assertNotNull(action.getProjectActions());
         assertEquals(1, action.getProjectActions().size());
-        assertSame(lastBuildAction, action.getProjectActions().iterator().next());
+        assertSame(action, action.getProjectActions().iterator().next());
     }
 }

--- a/src/test/java/hudson/plugins/chucknorris/ThirdRoundhouseActionTest.java
+++ b/src/test/java/hudson/plugins/chucknorris/ThirdRoundhouseActionTest.java
@@ -12,7 +12,7 @@ import junit.framework.TestCase;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-public class RoundhouseActionTest extends TestCase {
+public class ThirdRoundhouseActionTest extends TestCase {
 
     private RoundhouseAction action;
 
@@ -25,26 +25,16 @@ public class RoundhouseActionTest extends TestCase {
         action = new RoundhouseAction(Style.BAD_ASS, "Chuck Norris can divide by zero.");
 
         run = mock(Run.class);
+        given(run.getResult()).willReturn(Result.SUCCESS);
 
         lastBuildAction = new RoundhouseAction(Style.ALERT, "Chuck Norris went out of an infinite loop.");
         final Job job = mock(Job.class);
         Run<?, ?> lastRun = mock(Run.class);
-
-        given(run.getParent()).willAnswer(new Answer<Job>() {
-            @Override
-            public Job answer(InvocationOnMock invocation) throws Throwable {
-                return job;
-            }
-        });
-        given(job.getLastCompletedBuild()).willReturn(lastRun);
-        given(lastRun.getActions(eq(RoundhouseAction.class))).willReturn(Arrays.asList(lastBuildAction));
     }
 
-    public void testGetProjectActionsFromLastProjectBuild() {
+    public void testGetStyleFromRunResult() {
         action.onAttached(run);
 
-        assertNotNull(action.getProjectActions());
-        assertEquals(1, action.getProjectActions().size());
-        assertSame(lastBuildAction, action.getProjectActions().iterator().next());
+        assertEquals(Style.THUMB_UP, action.getStyle());
     }
 }


### PR DESCRIPTION
In our analysis of the project, we observed that 
1) 1 unnecessary stubbing which stubbed `getResult` method in `RoundhouseActionTest.setUp` is created but is never executed by the test `RoundhouseActionTest.testGetProjectActionsFromLastProjectBuild`;

2) 4 unnecessary stubbings `RoundhouseActionTest.setUp` are created but are never executed by 2 tests `RoundhouseActionTest.testAccessors`, `RoundhouseActionTest.testGetProjectActions`;

3) 3 unnecessary stubbings which stubbed `getParent` method, `getLastCompletedBuild` method, `getActions` method in `RoundhouseActionTest.setUp` are created but never executed by the tests `RoundhouseActionTest.testGetStyleFromRunResult`.

Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html). 

We propose below a solution to remove the unnecessary stubbings.